### PR TITLE
Automatic test run

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,0 +1,34 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Python package
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.7", "3.8", "3.9", "3.10"]
+
+    steps:
+    - uses: actions/checkout@v3
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v3
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        pip install -r requirements.txt
+        pip install -r requirements-dev.txt
+    - name: Test with pytest
+      run: |
+        pytest unittest

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -31,4 +31,4 @@ jobs:
         pip install -r requirements-dev.txt
     - name: Test with pytest
       run: |
-        pytest unittest
+        pytest unittests

--- a/pypey/pype.py
+++ b/pypey/pype.py
@@ -1810,6 +1810,10 @@ def _pipe(*arg: Any, functions: Tuple[Fn[..., Any], ...]) -> Any:
     # created as global function to avoid issues with multiprocessing
     result = arg if len(arg) > 1 else arg[0]
 
+    for f in functions:
+        if not callable(f):
+            raise TypeError(f"'{type(f).__name__}' object is not callable")
+
     for fn in functions:
         result = fn(result)
 


### PR DESCRIPTION
# 📖 What this PR brings

It brings this awesomeness to every pull request:
![](https://user-images.githubusercontent.com/73069/194730825-f2b1ad5f-8c08-4357-8a57-54cee971d248.png)

Libraries that claim to support certain versions of Python gain a lot more credibility if:

1. They have tests
2. They have decent coverage
3. The tests are run automatically against the supported Python versions

This PR tackles point 3 above.

But what about the positional-only parameters? I hear you ask. Well, I used `eval` for that, conditionally on the Python version. Gives you all the supported tests in each version.

Additionally, it includes a fix for a bug I found while running tests in Python 3.7:

> Explicitly raise TypeError with non-callables
> The docs say passing non-callables to 'to' will raise TypeError, but
> sometimes a bunch of calls have already happened by the time a
> non-callable is found.
> 
> This was causing tests to fail under Python 3.7, where some of the
> actually callable functions passed were raising other exceptions
> before control got the trying to call the non-callables.
